### PR TITLE
point homeassistant-historical-sensor to fork with 2025.11 fix

### DIFF
--- a/custom_components/auroraplus/manifest.json
+++ b/custom_components/auroraplus/manifest.json
@@ -7,7 +7,7 @@
   "codeowners": ["@LeighCurran","@shtrom"],
   "requirements": [
       "auroraplus@git+https://github.com/LeighCurran/AuroraPlus@main",
-      "homeassistant-historical-sensor==2.0.0rc6"
+      "homeassistant-historical-sensor@git+https://github.com/shtrom/ha-historical-sensor@2025.11-async_import_statistics-mean_type"
   ],
   "loggers": [ "auroraplus" ],
   "iot_class": "cloud_polling",

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
 # This should match the version in custom_components/auroraplus/manifest.json
 auroraplus@git+https://github.com/LeighCurran/AuroraPlus@main
-homeassistant_historical_sensor
+homeassistant-historical-sensor@git+https://github.com/shtrom/ha-historical-sensor@2025.11-async_import_statistics-mean_type
 
 # Test dependencies
 pytest


### PR DESCRIPTION
This is a temporary fix until [0] is merged and released

fixes: issue https://github.com/LeighCurran/AuroraPlusHA/issues/14

[0] https://github.com/ldotlopez/ha-historical-sensor/pull/17