### PR TITLE
Self-heal expired sessions via the OAuth B2C refresh_token

### DIFF
--- a/custom_components/auroraplus/api.py
+++ b/custom_components/auroraplus/api.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+import requests as plain_requests
 from auroraplus import AuroraPlusApi, AuroraPlusAuthenticationError
 from requests.exceptions import HTTPError
 
@@ -10,6 +11,82 @@ from homeassistant.exceptions import (
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def oauth_refresh_token(token: dict[str, Any]) -> dict[str, Any] | None:
+    """Use the OAuth B2C refresh_token to obtain a fresh id_token and refresh_token.
+
+    Aurora's API no longer returns a RefreshToken cookie from the LoginToken
+    endpoint, so the library's built-in refresh mechanism fails. This function
+    uses the OAuth refresh_token (from the original auth) to get a new id_token,
+    which can then be exchanged for a new access_token via LoginToken.
+    """
+    refresh_token = token.get("refresh_token")
+    if not refresh_token:
+        _LOGGER.warning("No OAuth refresh_token available for token refresh")
+        return None
+
+    try:
+        r = plain_requests.post(
+            AuroraPlusApi.TOKEN_URL,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": AuroraPlusApi.CLIENT_ID,
+                "scope": "openid offline_access",
+            },
+            timeout=30,
+        )
+        r.raise_for_status()
+        new_token = r.json()
+        _LOGGER.debug("OAuth refresh_token exchange succeeded")
+        return new_token
+    except Exception as e:
+        _LOGGER.warning(f"OAuth refresh_token exchange failed: {e}")
+        return None
+
+
+def aurora_reinit(api: AuroraPlusApi, token: dict[str, Any]) -> bool:
+    """Re-initialise an existing API object with a refreshed OAuth token.
+
+    Returns True on success, False on failure.
+    """
+    new_token = oauth_refresh_token(token)
+    if not new_token:
+        return False
+
+    # Merge the new OAuth fields into the existing token, preserving any extra keys
+    token.update({
+        "id_token": new_token["id_token"],
+        "refresh_token": new_token.get("refresh_token", token.get("refresh_token")),
+    })
+    # Clear the stale access_token so the library re-obtains it via id_token
+    token.pop("access_token", None)
+    token.pop("cookie_RefreshToken", None)
+
+    try:
+        new_api = AuroraPlusApi(token=token.copy())
+        new_api.get_info()
+
+        # Ensure the OAuth refresh_token is preserved in the api token dict
+        # so it survives into the config entry and can be used on future refreshes
+        new_refresh = token.get("refresh_token")
+        if new_refresh:
+            new_api.token["refresh_token"] = new_refresh
+
+        # Copy the refreshed state back onto the existing api object
+        api.session = new_api.session
+        api.token = new_api.token
+        api.customerId = new_api.customerId
+        api.serviceAgreementID = new_api.serviceAgreementID
+        api.premiseAddress = new_api.premiseAddress
+        api.Active = new_api.Active
+        api.Error = new_api.Error
+        _LOGGER.info("Successfully re-authenticated via OAuth refresh_token")
+        return True
+    except Exception as e:
+        _LOGGER.warning(f"Re-init after OAuth refresh failed: {e}")
+        return False
 
 
 def aurora_init(
@@ -22,6 +99,10 @@ def aurora_init(
         # ConfigEntry, both will always hold the same value in memory. If they are
         # the same, HA will not persist the updated value.
         api = AuroraPlusApi(token=token.copy())
+
+        # Preserve the OAuth refresh_token so it can be used for re-auth
+        if "refresh_token" in token and "refresh_token" not in api.token:
+            api.token["refresh_token"] = token["refresh_token"]
 
         # We need this data in AuroraPlusCoordinator.__init__so we have the
         # serviceAgreementID, preiseAddress, and tariffs over the previous

--- a/custom_components/auroraplus/coordinator.py
+++ b/custom_components/auroraplus/coordinator.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import Throttle
 
+from .api import aurora_reinit
 from .const import (
     CONF_TOKEN,
     CONF_SERVICE_AGREEMENT_ID,
@@ -68,17 +69,43 @@ class AuroraPlusCoordinator:
             _LOGGER.info(
                 "Successfully obtained data from " + self._api.day["StartDate"]
             )
-        except AuroraPlusAuthenticationError as e:
-            _LOGGER.exception(f"authentication failure on update: {e}")
-            self._config_entry.async_start_reauth(self._hass)
-        except HTTPError as e:
-            status_code = e.response.status_code
-            if status_code in [401, 403]:
-                _LOGGER.exception(f"authentication failure on update: {e}")
+        except (AuroraPlusAuthenticationError, HTTPError) as e:
+            is_auth_error = isinstance(e, AuroraPlusAuthenticationError) or (
+                isinstance(e, HTTPError) and e.response.status_code in [401, 403]
+            )
+            if not is_auth_error:
+                raise
+
+            _LOGGER.warning(f"Auth failure on update, attempting OAuth refresh: {e}")
+            entry_token = self._config_entry.data.get(CONF_TOKEN, {})
+            refreshed = await self._hass.async_add_executor_job(
+                aurora_reinit, self._api, entry_token
+            )
+            if refreshed:
+                # Retry the data fetch with the refreshed token
+                try:
+                    await self._hass.async_add_executor_job(self._api.getcurrent)
+                    for i in range(-1, -10, -1):
+                        await self._hass.async_add_executor_job(self._api.getday, i)
+                        if not self._api.day["NoDataFlag"]:
+                            await self._hass.async_add_executor_job(
+                                self._api.getsummary, i
+                            )
+                            break
+                    _LOGGER.info(
+                        "Successfully obtained data after OAuth refresh from "
+                        + self._api.day["StartDate"]
+                    )
+                except Exception as retry_e:
+                    _LOGGER.exception(
+                        f"Retry after OAuth refresh also failed: {retry_e}"
+                    )
+                    self._config_entry.async_start_reauth(self._hass)
+            else:
+                _LOGGER.error("OAuth refresh failed, requesting reauth")
                 self._config_entry.async_start_reauth(self._hass)
-            raise e
         except Exception as e:
-            _LOGGER.exception(f"authentication failure on update: {e}")
+            _LOGGER.exception(f"unexpected failure on update: {e}")
 
         await self.update_config_entry_token(self._hass, self._config_entry)
 


### PR DESCRIPTION
Aurora's `LoginToken` endpoint no longer returns the `RefreshToken` cookie the library's refresh path relies on (the refresh token now comes back in the JSON body as `refreshToken`, and the cookie is absent — the source of the familiar `Missing RefreshToken cookie in ... LoginToken response` log warning). Once the access token expires the integration can only start a reauth flow, so in practice it silently dies every day or two and all sensors go unavailable until the user pastes a fresh token JSON.

This PR adds a self-heal path that uses the **OAuth B2C refresh_token** from the original token exchange instead:

- on 401/403 or `AuroraPlusAuthenticationError` during an update, exchange the stored `refresh_token` at the B2C token endpoint (`grant_type=refresh_token`) for a fresh `id_token` + rotated `refresh_token`;
- rebuild the API session and retry the fetch once;
- persist the rotated token into the config entry (via the existing `update_config_entry_token`) so the refresh chain survives HA restarts;
- fall back to the existing reauth flow only when the refresh itself fails.

Known limitation, stated up front: Aurora's refresh tokens rotate and expire after ~24 h of disuse, so this keeps a continuously-running instance alive indefinitely, but an instance that was offline for more than a day still lands in the reauth flow as before.

This code has been running on my production instance (HA 2026.7) for a while — sessions now roll over automatically where they previously needed a manual reauth every day or two. I couldn't run the pytest suite locally (py3.12-only environment), so leaning on CI for that; happy to iterate.
